### PR TITLE
Add sizes of all objects in cluster/vnode/bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,17 @@ Once the sorted key logs are copied to a central location via `scp` (see section
     diff /tmp/cluster-v1/ /tmp/cluster-v2/
     ```
 
+### Finding size of all keys
+The output will appear in the form of `[node name]-[partition number]-sizes.log`. This function takes options as a list. The `with_metadata` option controls whether to return the whole object with metadata, or just the size of values. The `ignore_siblings` option controls whether to consider siblings in the calculations, or return the size of the first value (or an estimate of all the objects divided by the number of siblings).
+
+For example:
+
+```erlang
+key_list_util:size_all_keys("/tmp/", [with_metadata, ignore_siblings]).
+```
+
+The `size_all_keys()` function requires key duplication similar to `log_all_keys()` above. Its output adds a size of objects in bytes to the end of the `log_all_keys()` output.
+
 ### Logs of Objects with Siblings
 These will be named in the form of `[node name]-[partition number]-siblings.log`. (If no objects with siblings are found for a particular partition,
 no siblings log file will be created for that partition). The files consist of the following entries for each object, separated by a single blank line:

--- a/README.md
+++ b/README.md
@@ -206,12 +206,18 @@ Once the sorted key logs are copied to a central location via `scp` (see section
     ```
 
 ### Finding size of all keys
-The output will appear in the form of `[node name]-[partition number]-sizes.log`. This function takes options as a list. The `with_metadata` option controls whether to return the whole object with metadata, or just the size of values. The `ignore_siblings` option controls whether to consider siblings in the calculations, or return the size of the first value (or an estimate of all the objects divided by the number of siblings).
+The output will appear in the form of `[node name]-[partition number]-sizes.log`. This function can accept options as a list. If no options are required, you may leave off the argument. The `raw_size` option controls whether to return the whole object with metadata, or just the size of values. The `ignore_siblings` option controls whether to consider siblings in the calculations, or return the size of the first value (or an estimate of all the objects divided by the number of siblings). These two options are mutually exclusive. If both are provided, `raw_size` will take precedence, and the script will silently drop `ignore_siblings`.
 
 For example:
 
 ```erlang
-key_list_util:size_all_keys("/tmp/", [with_metadata, ignore_siblings]).
+key_list_util:size_all_keys("/tmp/").
+```
+
+Print out full object size, including any siblings:
+
+```erlang
+key_list_util:size_all_keys("/tmp/", [raw_size]).
 ```
 
 The `size_all_keys()` function requires key duplication similar to `log_all_keys()` above. Its output adds a size of objects in bytes to the end of the `log_all_keys()` output.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ riak-key-list-util
 A Riak console utility script for per-vnode key counting, siblings logging and more. (For Riak 1.1.4 and above)
 
 ## Usage
-This script needs to be run from a Riak console, on one of the Riak nodes. 
+This script needs to be run from a Riak console, on one of the Riak nodes. All nodes must be up and ready to accept requests or the script will fail. Every run of the script will append its output to the output of any previous run, so it’s a good idea to clear out the previous results.
 
 
 1. Clone this repository
@@ -206,7 +206,18 @@ Once the sorted key logs are copied to a central location via `scp` (see section
     ```
 
 ### Finding size of all keys
-The output will appear in the form of `[node name]-[partition number]-sizes.log`. This function can accept options as a list. If no options are required, you may leave off the argument. The `raw_size` option controls whether to return the whole object with metadata, or just the size of values. The `ignore_siblings` option controls whether to consider siblings in the calculations, or return the size of the first value (or an estimate of all the objects divided by the number of siblings). These two options are mutually exclusive. If both are provided, `raw_size` will take precedence, and the script will silently drop `ignore_siblings`.
+Finding the size of all keys works similarly to listing all keys. You can iterate over all partitions in the cluster, a single partition, or a single bucket. The six variations of the function are:
+
+```
+size_all_keys(OutputDir).
+size_all_keys(OutputDir, Options).
+size_all_keys_for_bucket(OutputDir, Bucket).
+size_all_keys_for_bucket(OutputDir, Bucket, Options).
+size_all_keys_for_vnode(OutputDir, Vnode).
+size_all_keys_for_vnode(OutputDir, Vnode, Options).
+```
+
+The output will appear in the form of `[node name]-[partition number]-sizes.log`. These functions can accept options as a list. If no options are required, you may leave off the argument. The `raw_size` option controls whether to return the whole object with metadata, or just the size of values. The `ignore_siblings` option controls whether to consider siblings in the calculations, or return the size of the first value (or an estimate of all the objects divided by the number of siblings). These two options are mutually exclusive. If both are provided, `raw_size` will take precedence, and the script will silently drop `ignore_siblings`.
 
 For example:
 
@@ -287,7 +298,7 @@ Whatever the case, the following function is there for use in such a case:
 local_direct_delete(Index, Bucket, Key)
 ```
 
-Here, **Index** is an integer representing the vnode or partition that the tombstone is on. **Bucket** and **Key** are binaries, as described above, and look like *<<"bucketOrKeyName">>*.
+Here, **Index** is an integer representing the vnode or partition that the tombstone is on. **Bucket** and **Key** are binaries, as described above, and look like *\<\<"bucketOrKeyName"\>\>*.
 
 <br>
 
@@ -305,4 +316,4 @@ Here, **Bucket** and **Key** are binaries as above. **NValue** is an integer rep
 
 <br>
 
-~
+\~

--- a/key_list_util.erl
+++ b/key_list_util.erl
@@ -66,6 +66,29 @@ log_all_keys_for_bucket(OutputDir, Bucket) ->
 log_all_keys_for_vnode(OutputDir, Vnode) ->
 	process_cluster_parallel_for_vnode(OutputDir, [log_keys], Vnode).
 
+% Find the size of data stored. Takes options to add object metadata and 
+% count siblings. Default is to only count value sizes and only the first 
+% returned sibling. Send Options as a list of atoms 
+% e.g. [with_metadata, ignore_siblings] to add metadata to results and count 
+% all siblings
+size_all_keys(OutputDir) ->
+	process_cluster_parallel(OutputDir, [size_keys]).
+
+size_all_keys(OutputDir, Options) ->
+	process_cluster_parallel(OutputDir, [size_keys|Options]).
+
+size_all_keys_for_bucket(OutputDir, Bucket) ->
+	process_cluster_parallel(OutputDir, [size_keys, {bucket, Bucket}]).
+
+size_all_keys_for_bucket(OutputDir, Bucket, Options) ->
+	process_cluster_parallel(OutputDir, [size_keys, {bucket, Bucket}] ++ Options).
+
+size_all_keys_for_vnode(OutputDir, Vnode) ->
+	process_cluster_parallel_for_vnode(OutputDir, [size_keys], Vnode).
+
+size_all_keys_for_vnode(OutputDir, Vnode, Options) ->
+	process_cluster_parallel_for_vnode(OutputDir, [size_keys|Options], Vnode).
+
 % SleepPeriod - optional amount of time to sleep between each key operation,
 % in milliseconds
 log_all_keys(OutputDir, SleepPeriod) ->
@@ -76,6 +99,11 @@ log_all_keys_for_bucket(OutputDir, SleepPeriod, Bucket) ->
 
 log_all_keys_for_vnode(OutputDir, SleepPeriod, Vnode) ->
 	process_cluster_parallel_for_vnode(OutputDir, [log_keys, {sleep_for, SleepPeriod}], Vnode).
+
+%% Call size_all_keys* functions like: 
+%%    size_all_keys_(OutputDir, [{sleep_for, SleepPeriod}])
+%% to sleep between key operations. Setting Options already creates a /2 function
+%% Other options can also be added to the call list
 
 resolve_all_siblings(OutputDir) ->
 	process_cluster_serial(OutputDir, [log_siblings, resolve_siblings]).
@@ -223,6 +251,46 @@ log_key(OutputFilename, Bucket, Key, Options) ->
 		_ -> ok
 	end.
 
+% Get the sibling count
+get_sibling_count(Bucket, Key, ObjBinary) ->
+	Obj = unserialize(Bucket, Key, ObjBinary),
+	case Obj of
+		{error, _Error} ->
+			1;  % Error unserializing, assume one sibling count
+		_ ->
+			riak_object:value_count(Obj)
+	end.
+
+% Log a key/bucket pair to a file with object sizes
+size_key(OutputFilename, Bucket, Key, ObjBinary, Options) ->
+	case lists:member(with_metadata, Options) of
+		true ->
+			case lists:member(ignore_siblings, Options) of
+				true ->
+					% Divide size by siblings to get an average size
+					ByteSize = (byte_size(ObjBinary) + 1) / get_sibling_count(Bucket, Key, ObjBinary);
+
+				_ ->
+					ByteSize = byte_size(ObjBinary)
+			end;
+		_ -> 
+			case lists:member(ignore_siblings, Options) of
+				true ->
+					[Value|_] = riak_object:get_values(unserialize(Bucket, Key, ObjBinary)),
+					ByteSize = byte_size(Value);
+				_ ->
+					% Get siblings
+					ByteSize = lists:foldl(fun(X,Sum) -> byte_size(X) + Sum end, 0, riak_object:get_values(unserialize(Bucket, Key, ObjBinary)))
+			end
+	end,
+	Msg = io_lib:format("~p,~s,~p~n", [Bucket, binary_to_list(Key), ByteSize]),
+	file:write_file(OutputFilename, Msg, [append]),
+	case lists:keyfind(sleep_for, 1, Options) of
+		{sleep_for, SleepPeriod} ->
+			timer:sleep(SleepPeriod);
+		_ -> ok
+	end.
+
 % Log all siblings for a riak object (if any exist).
 log_or_resolve_siblings(OutputFilename, Bucket, Key, ObjBinary, Options) ->
 	Obj = unserialize(Bucket, Key, ObjBinary),
@@ -311,6 +379,7 @@ process_vnode(Vnode, OutputDir, Options) ->
 	CountsFilename = filename:join(OutputDir, [io_lib:format("~s-~p-counts.log", [Node, Partition])]),
 	SiblingsFilename = filename:join(OutputDir, [io_lib:format("~s-~p-siblings.log", [Node, Partition])]),
 	KeysFilename = filename:join(OutputDir, [io_lib:format("~s-~p-keys.log", [Node, Partition])]),
+	SizesFilename = filename:join(OutputDir, [io_lib:format("~s-~p-sizes.log", [Node, Partition])]),
 
 	FoldOptions = case proplists:get_value(bucket, Options, undefined) of
 		undefined ->
@@ -326,6 +395,12 @@ process_vnode(Vnode, OutputDir, Options) ->
 		case lists:member(log_keys, Options) of
 			true ->
 				log_key(KeysFilename, Bucket, Key, Options);
+			_ -> ok
+		end,
+
+		case lists:member(size_keys, Options) of
+			true ->
+				size_key(SizesFilename, Bucket, Key, ObjBinary, Options);
 			_ -> ok
 		end,
 


### PR DESCRIPTION
Added size_all_keys, size_all_keys_for_vnode and size_all_keys_for_bucket. Outputs object sizes, including options for bare values, aggregating bare values with multiple siblings and returning raw objects.